### PR TITLE
🔀 :: (#71) TokenResponse에 Authority 추가 

### DIFF
--- a/src/main/java/com/project/dmsport/domain/auth/presentation/dto/response/TokenResponse.java
+++ b/src/main/java/com/project/dmsport/domain/auth/presentation/dto/response/TokenResponse.java
@@ -1,5 +1,6 @@
 package com.project.dmsport.domain.auth.presentation.dto.response;
 
+import com.project.dmsport.domain.user.domain.enums.Authority;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,5 +17,7 @@ public class TokenResponse {
     private final LocalDateTime expiredAt;
 
     private final String refreshToken;
+
+    private final Authority authority;
 
 }

--- a/src/main/java/com/project/dmsport/domain/notice/presentation/dto/response/QueryAllNoticesResponse.java
+++ b/src/main/java/com/project/dmsport/domain/notice/presentation/dto/response/QueryAllNoticesResponse.java
@@ -1,8 +1,6 @@
 package com.project.dmsport.domain.notice.presentation.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.project.dmsport.domain.notice.domain.enums.NoticeType;
-import com.project.dmsport.domain.user.domain.enums.Authority;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +14,6 @@ import java.util.List;
 public class QueryAllNoticesResponse {
 
     private final List<NoticeResponse> notices;
-    private final Authority authority;
     @Getter
     @Builder
     public static class NoticeResponse {

--- a/src/main/java/com/project/dmsport/domain/notice/service/QueryAllNoticesService.java
+++ b/src/main/java/com/project/dmsport/domain/notice/service/QueryAllNoticesService.java
@@ -1,7 +1,6 @@
 package com.project.dmsport.domain.notice.service;
 
 import com.project.dmsport.domain.notice.domain.Notice;
-import com.project.dmsport.domain.notice.domain.enums.NoticeType;
 import com.project.dmsport.domain.notice.domain.repository.NoticeRepository;
 import com.project.dmsport.domain.notice.presentation.dto.response.QueryAllNoticesResponse;
 import com.project.dmsport.domain.notice.presentation.dto.response.QueryAllNoticesResponse.NoticeResponse;
@@ -35,7 +34,7 @@ public class QueryAllNoticesService {
                                 .build()
                 ).collect(Collectors.toList());
 
-        return new QueryAllNoticesResponse(notices, user.getAuthority());
+        return new QueryAllNoticesResponse(notices);
     }
 
     private String generateContent(Notice notice) {

--- a/src/main/java/com/project/dmsport/domain/user/service/LoginService.java
+++ b/src/main/java/com/project/dmsport/domain/user/service/LoginService.java
@@ -40,6 +40,7 @@ public class LoginService {
                 .accessToken(accessToken)
                 .expiredAt(LocalDateTime.now().plusSeconds(jwtProperties.getAccessExp()))
                 .refreshToken(refreshToken)
+                .authority(user.getAuthority())
                 .build();
     }
 }

--- a/src/main/java/com/project/dmsport/domain/user/service/SignupService.java
+++ b/src/main/java/com/project/dmsport/domain/user/service/SignupService.java
@@ -41,7 +41,7 @@ public class SignupService {
 
         authCodeFacade.checkIsVerified(email);
 
-        userRepository.save(User
+        User user = userRepository.save(User
                 .builder()
                 .name(name)
                 .email(email)
@@ -58,6 +58,7 @@ public class SignupService {
                 .accessToken(accessToken)
                 .expiredAt(LocalDateTime.now().plusSeconds(jwtProperties.getAccessExp()))
                 .refreshToken(refreshToken)
+                .authority(user.getAuthority())
                 .build();
     }
 }


### PR DESCRIPTION
### 해당 이슈⚡️

- resolved #71

### 변경사항✅

- TokenResponse에 Authority를 넣어서 그걸로 권한 판별을 할 수 있도록 해달라는 요청이 있었습니다.
- 따라서 **TokenResponse에 Authority 추가**
- **공지 목록 조회에서 Authority 삭제**