### PR TITLE
🔀 ::  (#75) 비밀번호 찾기 권한 permitAll

### DIFF
--- a/src/main/java/com/project/dmsport/domain/user/presentation/UserController.java
+++ b/src/main/java/com/project/dmsport/domain/user/presentation/UserController.java
@@ -32,7 +32,7 @@ public class UserController {
 
     private final UpdatePasswordService updatePasswordService;
 
-    private final SendAuthCodeService sendAuthCodeService;
+    private final SendPasswordFindCodeService sendPasswordCodeService;
     private final FindPasswordService findPasswordService;
 
     private final LogoutService logoutService;
@@ -81,9 +81,9 @@ public class UserController {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PostMapping("/mail")
-    public void sendAuthCodeService(@RequestBody @Valid SendAuthCodeRequest request){
-        sendAuthCodeService.execute(request);
+    @PostMapping("/mail/find")
+    public void sendPasswordFindCodeService(@RequestBody @Valid SendAuthCodeRequest request){
+        sendPasswordCodeService.execute(request);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/project/dmsport/domain/user/service/SendPasswordFindCodeService.java
+++ b/src/main/java/com/project/dmsport/domain/user/service/SendPasswordFindCodeService.java
@@ -7,16 +7,14 @@ import com.project.dmsport.domain.user.presentation.dto.request.SendAuthCodeRequ
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import javax.validation.Valid;
-
 @RequiredArgsConstructor
 @Service
-public class SendAuthCodeService {
+public class SendPasswordFindCodeService {
 
     private final AuthCodeFacade authCodeFacade;
     private final UserFacade userFacade;
 
-    public void execute(@Valid SendAuthCodeRequest request) {
+    public void execute(SendAuthCodeRequest request) {
 
         String email = request.getEmail();
 

--- a/src/main/java/com/project/dmsport/global/security/SecurityConfig.java
+++ b/src/main/java/com/project/dmsport/global/security/SecurityConfig.java
@@ -53,6 +53,8 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.POST, "/users").permitAll()
                 .antMatchers(HttpMethod.POST, "/users/auth").permitAll()
                 .antMatchers(HttpMethod.PUT, "/users/auth").permitAll()
+                .antMatchers(HttpMethod.POST, "/users/password").permitAll()
+                .antMatchers(HttpMethod.POST, "/mail/find").permitAll()
 
                 .antMatchers(HttpMethod.POST, "/notices/club").hasAnyAuthority(
                         "BASKETBALL_MANAGER", "VOLLEYBALL_MANAGER", "BADMINTON_MANAGER", "SOCCER_MANAGER")


### PR DESCRIPTION
### 해당 이슈⚡️

- resolved #75

### 변경사항✅

- 비번 찾기 권한 `permitAll()`로 변경
-  SendAuthCodeService를 SendPasswordFindCodeService로 변경함
    - 비밀번호 찾기 메일 전송이라는 의미를 드러내기 위함