### PR TITLE
🔀 :: (#77)최근공지 조회

### DIFF
--- a/src/main/java/com/project/dmsport/domain/notice/domain/Notice.java
+++ b/src/main/java/com/project/dmsport/domain/notice/domain/Notice.java
@@ -49,4 +49,8 @@ public class Notice extends BaseTimeEntity {
         this.title = title;
         this.content = content;
     }
+
+    public String generateContent() {
+        return content.length()>20 ? content.substring(0,19):content;
+    }
 }

--- a/src/main/java/com/project/dmsport/domain/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/com/project/dmsport/domain/notice/domain/repository/NoticeRepository.java
@@ -1,10 +1,17 @@
 package com.project.dmsport.domain.notice.domain.repository;
 
 import com.project.dmsport.domain.notice.domain.Notice;
+import com.project.dmsport.domain.notice.domain.enums.NoticeType;
 import org.springframework.data.repository.CrudRepository;
 
+import javax.persistence.OrderBy;
 import java.util.List;
 
 public interface NoticeRepository extends CrudRepository<Notice, Long> {
     List<Notice> findAllByOrderByCreatedDateDesc();
+
+
+    List<Notice> findTop2ByNoticeTypeOrderByCreatedDateDesc(NoticeType noticeType);
+
+    List<Notice> findTop2ByNoticeTypeNotOrderByCreatedDateDesc(NoticeType noticeType);
 }

--- a/src/main/java/com/project/dmsport/domain/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/project/dmsport/domain/notice/facade/NoticeFacade.java
@@ -5,9 +5,13 @@ import com.project.dmsport.domain.notice.domain.enums.NoticeType;
 import com.project.dmsport.domain.notice.domain.repository.NoticeRepository;
 import com.project.dmsport.domain.notice.exception.InvalidAuthorityException;
 import com.project.dmsport.domain.notice.exception.NoticeNotFoundException;
+import com.project.dmsport.domain.notice.presentation.dto.response.NoticeResponse;
 import com.project.dmsport.domain.user.domain.enums.Authority;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Component
@@ -19,4 +23,21 @@ public class NoticeFacade {
                 .orElseThrow(() -> NoticeNotFoundException.EXCEPTION);
     }
 
+    public List<NoticeResponse> noticeToNoticeResponse(List<Notice> notices) {
+        return notices.stream()
+                .map(
+                        n -> NoticeResponse.builder()
+                                .id(n.getId())
+                                .title(n.getTitle())
+                                .contentPreview(generateContent(n))
+                                .type(n.getNoticeType())
+                                .createdAt(n.getCreatedDate())
+                                .build()
+                ).collect(Collectors.toList());
+    }
+
+    private String generateContent(Notice notice) {
+        String content = notice.getContent();
+        return content.length() > 20 ? content.substring(0, 20) : content;
+    }
 }

--- a/src/main/java/com/project/dmsport/domain/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/project/dmsport/domain/notice/facade/NoticeFacade.java
@@ -1,17 +1,10 @@
 package com.project.dmsport.domain.notice.facade;
 
 import com.project.dmsport.domain.notice.domain.Notice;
-import com.project.dmsport.domain.notice.domain.enums.NoticeType;
 import com.project.dmsport.domain.notice.domain.repository.NoticeRepository;
-import com.project.dmsport.domain.notice.exception.InvalidAuthorityException;
 import com.project.dmsport.domain.notice.exception.NoticeNotFoundException;
-import com.project.dmsport.domain.notice.presentation.dto.response.NoticeResponse;
-import com.project.dmsport.domain.user.domain.enums.Authority;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Component
@@ -21,23 +14,5 @@ public class NoticeFacade {
     public Notice findNoticeById(Long id) {
         return noticeRepository.findById(id)
                 .orElseThrow(() -> NoticeNotFoundException.EXCEPTION);
-    }
-
-    public List<NoticeResponse> noticeToNoticeResponse(List<Notice> notices) {
-        return notices.stream()
-                .map(
-                        n -> NoticeResponse.builder()
-                                .id(n.getId())
-                                .title(n.getTitle())
-                                .contentPreview(generateContent(n))
-                                .type(n.getNoticeType())
-                                .createdAt(n.getCreatedDate())
-                                .build()
-                ).collect(Collectors.toList());
-    }
-
-    private String generateContent(Notice notice) {
-        String content = notice.getContent();
-        return content.length() > 20 ? content.substring(0, 20) : content;
     }
 }

--- a/src/main/java/com/project/dmsport/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/com/project/dmsport/domain/notice/presentation/NoticeController.java
@@ -3,6 +3,7 @@ package com.project.dmsport.domain.notice.presentation;
 import com.project.dmsport.domain.notice.domain.enums.NoticeType;
 import com.project.dmsport.domain.notice.presentation.dto.request.CreateNoticeRequest;
 import com.project.dmsport.domain.notice.presentation.dto.request.ModifyNoticeRequest;
+import com.project.dmsport.domain.notice.presentation.dto.response.NoticeResponse;
 import com.project.dmsport.domain.notice.presentation.dto.response.QueryAllNoticesResponse;
 import com.project.dmsport.domain.notice.presentation.dto.response.QueryNoticeDetailResponse;
 import com.project.dmsport.domain.notice.service.*;
@@ -11,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/notices")
@@ -22,9 +25,15 @@ public class NoticeController {
     private final CreateClubNoticeService createClubNoticeService;
     private final ModifyNoticeService modifyNoticeService;
     private final DeleteNoticeService deleteNoticeService;
+    private final QueryRecentNoticeService queryRecentNoticeService;
     @GetMapping
     public QueryAllNoticesResponse searchNoticeList() {
         return queryAllNoticesService.execute();
+    }
+
+    @GetMapping("/recent")
+    public Map<String, List<NoticeResponse>> searchRecentNoticeList() {
+        return queryRecentNoticeService.execute();
     }
 
     @GetMapping("/{notice-id}")
@@ -55,4 +64,5 @@ public class NoticeController {
     public void deleteNotice(@PathVariable("notice-id") Long noticeId) {
         deleteNoticeService.execute(noticeId);
     }
+
 }

--- a/src/main/java/com/project/dmsport/domain/notice/presentation/dto/response/NoticeResponse.java
+++ b/src/main/java/com/project/dmsport/domain/notice/presentation/dto/response/NoticeResponse.java
@@ -1,5 +1,6 @@
 package com.project.dmsport.domain.notice.presentation.dto.response;
 
+import com.project.dmsport.domain.notice.domain.Notice;
 import com.project.dmsport.domain.notice.domain.enums.NoticeType;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,4 +15,14 @@ public class NoticeResponse {
     private final String contentPreview;
     private final NoticeType type;
     private final LocalDateTime createdAt;
+
+    public static NoticeResponse of(Notice notice) {
+        return NoticeResponse.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .contentPreview(notice.generateContent())
+                .type(notice.getNoticeType())
+                .createdAt(notice.getCreatedDate())
+                .build();
+    }
 }

--- a/src/main/java/com/project/dmsport/domain/notice/presentation/dto/response/NoticeResponse.java
+++ b/src/main/java/com/project/dmsport/domain/notice/presentation/dto/response/NoticeResponse.java
@@ -1,17 +1,17 @@
 package com.project.dmsport.domain.notice.presentation.dto.response;
 
 import com.project.dmsport.domain.notice.domain.enums.NoticeType;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.List;
-
 
 @Getter
-@AllArgsConstructor
-public class QueryAllNoticesResponse {
-
-    private final List<NoticeResponse> notices;
+@Builder
+public class NoticeResponse {
+    private final Long id;
+    private final String title;
+    private final String contentPreview;
+    private final NoticeType type;
+    private final LocalDateTime createdAt;
 }

--- a/src/main/java/com/project/dmsport/domain/notice/service/QueryAllNoticesService.java
+++ b/src/main/java/com/project/dmsport/domain/notice/service/QueryAllNoticesService.java
@@ -2,22 +2,27 @@ package com.project.dmsport.domain.notice.service;
 
 import com.project.dmsport.domain.notice.domain.repository.NoticeRepository;
 import com.project.dmsport.domain.notice.facade.NoticeFacade;
+import com.project.dmsport.domain.notice.presentation.dto.response.NoticeResponse;
 import com.project.dmsport.domain.notice.presentation.dto.response.QueryAllNoticesResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class QueryAllNoticesService {
 
     private final NoticeRepository noticeRepository;
-    private final NoticeFacade noticeFacade;
 
     @Transactional(readOnly = true)
     public QueryAllNoticesResponse execute() {
-
-        return new QueryAllNoticesResponse(
-                noticeFacade.noticeToNoticeResponse(noticeRepository.findAllByOrderByCreatedDateDesc()));
+        List<NoticeResponse> notices = noticeRepository.findAllByOrderByCreatedDateDesc()
+                .stream()
+                .map(NoticeResponse::of)
+                .collect(Collectors.toList());
+        return new QueryAllNoticesResponse(notices);
     }
 }

--- a/src/main/java/com/project/dmsport/domain/notice/service/QueryAllNoticesService.java
+++ b/src/main/java/com/project/dmsport/domain/notice/service/QueryAllNoticesService.java
@@ -1,42 +1,23 @@
 package com.project.dmsport.domain.notice.service;
 
-import com.project.dmsport.domain.notice.domain.Notice;
 import com.project.dmsport.domain.notice.domain.repository.NoticeRepository;
+import com.project.dmsport.domain.notice.facade.NoticeFacade;
 import com.project.dmsport.domain.notice.presentation.dto.response.QueryAllNoticesResponse;
-import com.project.dmsport.domain.notice.presentation.dto.response.QueryAllNoticesResponse.NoticeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class QueryAllNoticesService {
 
     private final NoticeRepository noticeRepository;
+    private final NoticeFacade noticeFacade;
 
     @Transactional(readOnly = true)
     public QueryAllNoticesResponse execute() {
 
-        List<NoticeResponse> notices = noticeRepository.findAllByOrderByCreatedDateDesc()
-                .stream()
-                .map(
-                        n -> NoticeResponse.builder()
-                                .id(n.getId())
-                                .title(n.getTitle())
-                                .contentPreview(generateContent(n))
-                                .type(n.getNoticeType())
-                                .createdAt(n.getCreatedDate())
-                                .build()
-                ).collect(Collectors.toList());
-
-        return new QueryAllNoticesResponse(notices);
-    }
-
-    private String generateContent(Notice notice) {
-        String content = notice.getContent();
-        return content.length() > 20 ? content.substring(0, 20) : content;
+        return new QueryAllNoticesResponse(
+                noticeFacade.noticeToNoticeResponse(noticeRepository.findAllByOrderByCreatedDateDesc()));
     }
 }

--- a/src/main/java/com/project/dmsport/domain/notice/service/QueryRecentNoticeService.java
+++ b/src/main/java/com/project/dmsport/domain/notice/service/QueryRecentNoticeService.java
@@ -2,7 +2,6 @@ package com.project.dmsport.domain.notice.service;
 
 import com.project.dmsport.domain.notice.domain.enums.NoticeType;
 import com.project.dmsport.domain.notice.domain.repository.NoticeRepository;
-import com.project.dmsport.domain.notice.facade.NoticeFacade;
 import com.project.dmsport.domain.notice.presentation.dto.response.NoticeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,23 +9,28 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class QueryRecentNoticeService {
     private final NoticeRepository noticeRepository;
-    private final NoticeFacade noticeFacade;
 
     public Map<String, List<NoticeResponse>> execute() {
 
-        List<NoticeResponse> admin = noticeFacade.noticeToNoticeResponse(
-                noticeRepository.findTop2ByNoticeTypeOrderByCreatedDateDesc(NoticeType.ALL));
-        List<NoticeResponse> manager = noticeFacade.noticeToNoticeResponse(
-                noticeRepository.findTop2ByNoticeTypeNotOrderByCreatedDateDesc(NoticeType.ALL));
+        List<NoticeResponse> adminNoticeList = noticeRepository.findTop2ByNoticeTypeOrderByCreatedDateDesc(NoticeType.ALL)
+                .stream()
+                .map(NoticeResponse::of)
+                .collect(Collectors.toList());
+
+        List<NoticeResponse> managerNoticeList = noticeRepository.findTop2ByNoticeTypeNotOrderByCreatedDateDesc(NoticeType.ALL)
+                .stream()
+                .map(NoticeResponse::of)
+                .collect(Collectors.toList());
 
         Map<String, List<NoticeResponse>> res = new HashMap<>();
-        res.put("admin", admin);
-        res.put("manager", manager);
+        res.put("admin", adminNoticeList);
+        res.put("manager", managerNoticeList);
         return res;
 
     }

--- a/src/main/java/com/project/dmsport/domain/notice/service/QueryRecentNoticeService.java
+++ b/src/main/java/com/project/dmsport/domain/notice/service/QueryRecentNoticeService.java
@@ -1,0 +1,33 @@
+package com.project.dmsport.domain.notice.service;
+
+import com.project.dmsport.domain.notice.domain.enums.NoticeType;
+import com.project.dmsport.domain.notice.domain.repository.NoticeRepository;
+import com.project.dmsport.domain.notice.facade.NoticeFacade;
+import com.project.dmsport.domain.notice.presentation.dto.response.NoticeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class QueryRecentNoticeService {
+    private final NoticeRepository noticeRepository;
+    private final NoticeFacade noticeFacade;
+
+    public Map<String, List<NoticeResponse>> execute() {
+
+        List<NoticeResponse> admin = noticeFacade.noticeToNoticeResponse(
+                noticeRepository.findTop2ByNoticeTypeOrderByCreatedDateDesc(NoticeType.ALL));
+        List<NoticeResponse> manager = noticeFacade.noticeToNoticeResponse(
+                noticeRepository.findTop2ByNoticeTypeNotOrderByCreatedDateDesc(NoticeType.ALL));
+
+        Map<String, List<NoticeResponse>> res = new HashMap<>();
+        res.put("admin", admin);
+        res.put("manager", manager);
+        return res;
+
+    }
+}

--- a/src/main/java/com/project/dmsport/global/security/SecurityConfig.java
+++ b/src/main/java/com/project/dmsport/global/security/SecurityConfig.java
@@ -59,7 +59,8 @@ public class SecurityConfig {
 
                 .antMatchers(HttpMethod.POST, "/notices/club").hasAnyAuthority(
                         "BASKETBALL_MANAGER", "VOLLEYBALL_MANAGER", "BADMINTON_MANAGER", "SOCCER_MANAGER")
-                .antMatchers(HttpMethod.POST, "/notices/all").hasAuthority("ADMIN")
+                .antMatchers(HttpMethod.POST, "/notices/admin").hasAuthority("ADMIN")
+                .antMatchers(HttpMethod.GET, "/notices/recent").authenticated()
 
                 .antMatchers(HttpMethod.POST, "/admin/club").hasAuthority("ADMIN")
                 .antMatchers(HttpMethod.PATCH, "/admin/ban").hasAuthority("ADMIN")
@@ -72,7 +73,7 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.POST, "/clubs/schedule/hope").hasAnyAuthority(
                         "BASKETBALL_MANAGER", "VOLLEYBALL_MANAGER", "BADMINTON_MANAGER", "SOCCER_MANAGER")
 
-                .anyRequest().authenticated()
+                .anyRequest().permitAll()
 
                 .and()
                 .apply(new FilterConfig(jwtTokenProvider, objectMapper))

--- a/src/main/java/com/project/dmsport/global/security/SecurityConfig.java
+++ b/src/main/java/com/project/dmsport/global/security/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.POST, "/clubs/schedule/hope").hasAnyAuthority(
                         "BASKETBALL_MANAGER", "VOLLEYBALL_MANAGER", "BADMINTON_MANAGER", "SOCCER_MANAGER")
 
-                .anyRequest().permitAll()
+                .anyRequest().authenticated()
 
                 .and()
                 .apply(new FilterConfig(jwtTokenProvider, objectMapper))


### PR DESCRIPTION
### 해당 이슈⚡️

-close #77

### 변경사항✅

- 최근공지 기능 추가 map사용
- 조회된 타입인 Notice에서 반환할 타입인 NoticeType을로 바꾸는 코드를
  facade로 묶었습니다.
- 그 따로 @OrderBy어노테이션 사용할려 했는데 검색해보니까 보통 엔티티 컬럼에 쓰는거같은데
  아무리 해봐도 적용이 되질 않아서 일단 NoticeRepository에 달아놨습니다.
- 접근 권한설정
